### PR TITLE
feat: build /blog route

### DIFF
--- a/src/content/posts/draft-post.md
+++ b/src/content/posts/draft-post.md
@@ -1,0 +1,10 @@
+---
+title: Draft Post (Jangan Tampil)
+date: 2026-05-01
+description: Post ini adalah draft dan seharusnya tidak muncul di halaman blog.
+tags:
+  - test
+draft: true
+---
+
+Post ini tidak seharusnya tampil.

--- a/src/content/posts/second-post.md
+++ b/src/content/posts/second-post.md
@@ -1,0 +1,11 @@
+---
+title: Second Post
+date: 2026-04-15
+description: Post kedua untuk menguji urutan sorting berdasarkan tanggal.
+tags:
+  - test
+  - sorting
+draft: false
+---
+
+Post kedua untuk keperluan testing sort order.

--- a/src/lib/config/nav.ts
+++ b/src/lib/config/nav.ts
@@ -1,4 +1,5 @@
 export const navItems: { label: string; href: string }[] = [
 	{ label: 'Home', href: '/' },
+	{ label: 'Blog', href: '/blog' },
 	{ label: 'About', href: '/about' },
 ];

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,15 @@
+import type { Post, PostMetadata } from '$lib/types/post';
+
+type GlobModule = { metadata: PostMetadata };
+
+export function getAllPosts(): Post[] {
+	const modules = import.meta.glob<GlobModule>('../content/posts/*.md', { eager: true });
+
+	return Object.entries(modules)
+		.map(([path, mod]) => {
+			const slug = path.split('/').pop()!.replace(/\.md$/, '');
+			return { slug, ...mod.metadata };
+		})
+		.filter((post) => !post.draft)
+		.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}

--- a/src/lib/types/post.ts
+++ b/src/lib/types/post.ts
@@ -5,3 +5,7 @@ export type PostMetadata = {
 	tags: string[];
 	draft: boolean;
 };
+
+export type Post = PostMetadata & {
+	slug: string;
+};

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	function formatDate(date: string) {
+		return new Date(date).toLocaleDateString('id-ID', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric'
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>Blog — Lookqup</title>
+	<meta name="description" content="Kumpulan tulisan dan catatan dari Lookqup." />
+</svelte:head>
+
+<div class="mx-auto max-w-2xl">
+	<header class="mb-10">
+		<h1 class="text-3xl font-bold text-foreground">Blog</h1>
+		<p class="mt-2 text-muted-foreground">Kumpulan tulisan dan catatan.</p>
+	</header>
+
+	{#if data.posts.length === 0}
+		<p class="text-muted-foreground">Belum ada post yang dipublikasikan.</p>
+	{:else}
+		<ul class="flex flex-col gap-4">
+			{#each data.posts as post}
+				<li>
+					<a
+						href="/posts/{post.slug}"
+						class="block rounded-xl border border-border bg-surface p-5 transition-colors hover:border-primary hover:bg-muted"
+					>
+						<article>
+							<h2 class="text-lg font-semibold text-foreground">{post.title}</h2>
+							<time class="mt-1 block text-xs text-muted-foreground" datetime={post.date}>
+								{formatDate(post.date)}
+							</time>
+							<p class="mt-2 text-sm text-muted-foreground">{post.description}</p>
+							{#if post.tags.length > 0}
+								<div class="mt-3 flex flex-wrap gap-2">
+									{#each post.tags as tag}
+										<span class="rounded-full bg-muted px-2.5 py-0.5 text-xs text-muted-foreground">
+											{tag}
+										</span>
+									{/each}
+								</div>
+							{/if}
+						</article>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/src/routes/blog/+page.ts
+++ b/src/routes/blog/+page.ts
@@ -1,0 +1,5 @@
+import { getAllPosts } from '$lib/posts';
+
+export function load() {
+	return { posts: getAllPosts() };
+}


### PR DESCRIPTION
## Summary

- Utility function `getAllPosts()` di `src/lib/posts.ts` — membaca semua post via `import.meta.glob`, filter draft, sort by date descending
- Route `/blog` dengan card layout (title, date, description, tags) dan empty state
- Tambah `Post` type (`PostMetadata` + `slug`) di `src/lib/types/post.ts`
- Tambah Blog ke nav items

## Test plan

- [ ] `/blog` menampilkan daftar post non-draft
- [ ] Post `draft: true` tidak muncul
- [ ] Urutan terbaru di atas
- [ ] Klik card mengarah ke `/posts/<slug>`
- [ ] `pnpm build` berhasil tanpa error

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)