### PR TITLE
feat: TOC dengan scroll-spy untuk halaman blog

### DIFF
--- a/mdsvex.config.js
+++ b/mdsvex.config.js
@@ -1,5 +1,7 @@
 import { defineMDSveXConfig } from 'mdsvex';
 import { getSingletonHighlighter } from 'shiki';
+import rehypeSlug from 'rehype-slug';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 
 // Escape characters that are special inside Svelte template literals and {@html} blocks.
 // Mirrors mdsvex's internal escape_svelty function.
@@ -54,5 +56,16 @@ async function highlighter(code, lang) {
 export default defineMDSveXConfig({
 	extensions: ['.md', '.svx'],
 	smartypants: true,
-	highlight: { highlighter }
+	highlight: { highlighter },
+	rehypePlugins: [
+		rehypeSlug,
+		[
+			rehypeAutolinkHeadings,
+			{
+				behavior: 'append',
+				properties: { class: 'heading-anchor', ariaLabel: 'Link to heading' },
+				content: { type: 'text', value: '#' }
+			}
+		]
+	]
 });

--- a/package.json
+++ b/package.json
@@ -20,11 +20,16 @@
 		"@tailwindcss/vite": "^4.2.4",
 		"@types/node": "^25.6.0",
 		"mdsvex": "^0.12.7",
+		"rehype-autolink-headings": "^7.1.0",
+		"rehype-slug": "^6.0.0",
 		"shiki": "^4.0.2",
 		"svelte": "^5.55.2",
 		"svelte-check": "^4.4.6",
 		"tailwindcss": "^4.2.4",
 		"typescript": "^6.0.2",
 		"vite": "^8.0.7"
+	},
+	"dependencies": {
+		"github-slugger": "^2.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
@@ -32,6 +36,12 @@ importers:
       mdsvex:
         specifier: ^0.12.7
         version: 0.12.7(svelte@5.55.5)
+      rehype-autolink-headings:
+        specifier: ^7.1.0
+        version: 7.1.0
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
@@ -402,6 +412,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -464,6 +477,9 @@ packages:
       '@typescript-eslint/types':
         optional: true
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -478,17 +494,33 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
@@ -664,6 +696,12 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
+  rehype-autolink-headings@7.1.0:
+    resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
+
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -724,6 +762,9 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -734,6 +775,9 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
@@ -1121,6 +1165,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
   ccount@2.0.1: {}
 
   character-entities-html4@2.1.0: {}
@@ -1162,6 +1208,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  extend@3.0.2: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -1169,7 +1217,17 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  github-slugger@2.0.0: {}
+
   graceful-fs@4.2.11: {}
+
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hast-util-to-html@9.0.5:
     dependencies:
@@ -1185,11 +1243,17 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
 
   html-void-elements@3.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-reference@3.0.3:
     dependencies:
@@ -1342,6 +1406,23 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  rehype-autolink-headings@7.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-is-element: 3.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
+
   rolldown@1.0.0-rc.17:
     dependencies:
       '@oxc-project/types': 0.127.0
@@ -1441,12 +1522,24 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  trough@2.2.0: {}
+
   tslib@2.8.1:
     optional: true
 
   typescript@6.0.3: {}
 
   undici-types@7.19.2: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
 
   unist-util-is@4.1.0: {}
 

--- a/src/app.css
+++ b/src/app.css
@@ -42,6 +42,8 @@
 @layer base {
   html {
     font-family: var(--font-sans);
+    scroll-behavior: smooth;
+    scroll-padding-top: 6rem;
   }
   body {
     background-color: var(--background);

--- a/src/app.css
+++ b/src/app.css
@@ -52,6 +52,18 @@
 }
 
 @layer components {
+  /* Heading anchor links from rehype-autolink-headings */
+  .prose :is(h1, h2, h3, h4, h5, h6) .heading-anchor {
+    opacity: 0;
+    margin-left: 0.375rem;
+    text-decoration: none;
+    transition: opacity 0.15s;
+  }
+
+  .prose :is(h1, h2, h3, h4, h5, h6):hover .heading-anchor {
+    opacity: 1;
+  }
+
   /* Shiki code block container */
   .prose .shiki {
     background-color: var(--surface) !important;

--- a/src/content/posts/toc-demo.md
+++ b/src/content/posts/toc-demo.md
@@ -1,0 +1,196 @@
+---
+title: Panduan Lengkap SvelteKit untuk Pemula
+date: 2026-05-03
+description: Panduan komprehensif membangun aplikasi web modern dengan SvelteKit, mulai dari instalasi hingga deployment.
+tags:
+  - sveltekit
+  - svelte
+  - tutorial
+draft: false
+---
+
+SvelteKit adalah framework full-stack untuk membangun aplikasi web dengan Svelte. Post ini mencakup semua yang perlu kamu tahu untuk mulai membangun aplikasi produksi — scroll ke bawah dan perhatikan TOC di kanan yang mengikuti posisimu.
+
+## Instalasi dan Setup
+
+Cara termudah memulai project SvelteKit baru adalah dengan `create-svelte`:
+
+```bash
+pnpm create svelte@latest my-app
+cd my-app
+pnpm install
+pnpm dev
+```
+
+Kamu akan diminta memilih template (Skeleton, SvelteKit Demo, Library), TypeScript, dan beberapa opsi lain. Untuk project baru, pilih **Skeleton** dengan TypeScript.
+
+### Struktur Direktori
+
+Setelah setup, struktur project akan terlihat seperti ini:
+
+```
+my-app/
+├── src/
+│   ├── routes/          ← semua halaman ada di sini
+│   │   └── +page.svelte ← halaman utama (/)
+│   ├── lib/             ← komponen dan utilitas
+│   └── app.html         ← HTML template
+├── static/              ← file statis (favicon, dll)
+├── svelte.config.js
+└── vite.config.ts
+```
+
+### Menjalankan Dev Server
+
+```bash
+pnpm dev          # http://localhost:5173
+pnpm dev --open   # langsung buka browser
+```
+
+## Routing
+
+SvelteKit menggunakan file-system routing. Setiap file `+page.svelte` di dalam `src/routes/` menjadi sebuah halaman.
+
+### Route Dasar
+
+| File | URL |
+|---|---|
+| `src/routes/+page.svelte` | `/` |
+| `src/routes/about/+page.svelte` | `/about` |
+| `src/routes/blog/+page.svelte` | `/blog` |
+
+### Dynamic Routes
+
+Untuk halaman dinamis seperti `/blog/my-post`, gunakan folder dengan nama dalam kurung siku:
+
+```
+src/routes/blog/[slug]/+page.svelte
+```
+
+Parameter `slug` kemudian tersedia lewat `$page.params.slug` atau dari fungsi `load`.
+
+### Layout
+
+File `+layout.svelte` berlaku untuk semua halaman di direktori yang sama dan di bawahnya. Gunakan ini untuk header, footer, dan navigation yang konsisten:
+
+```svelte
+<!-- src/routes/+layout.svelte -->
+<script>
+  let { children } = $props();
+</script>
+
+<header><!-- nav --></header>
+<main>{@render children()}</main>
+<footer><!-- footer --></footer>
+```
+
+## Loading Data
+
+SvelteKit memisahkan logika data dari komponen UI melalui file `+page.ts` (atau `+page.server.ts` untuk server-only).
+
+### Client + Server Load
+
+```typescript
+// src/routes/blog/[slug]/+page.ts
+export async function load({ params, fetch }) {
+  const post = await fetch(`/api/posts/${params.slug}`);
+  return { post: await post.json() };
+}
+```
+
+Data yang di-return langsung tersedia di komponen sebagai `data.post`:
+
+```svelte
+<script>
+  let { data } = $props();
+</script>
+
+<h1>{data.post.title}</h1>
+```
+
+### Server-Only Load
+
+Gunakan `+page.server.ts` untuk akses database, secrets, atau logika yang tidak boleh ke client:
+
+```typescript
+// src/routes/dashboard/+page.server.ts
+import { db } from '$lib/db';
+import { redirect } from '@sveltejs/kit';
+
+export async function load({ locals }) {
+  if (!locals.user) redirect(303, '/login');
+  return { stats: await db.getStats(locals.user.id) };
+}
+```
+
+## Deployment
+
+SvelteKit mendukung berbagai target deployment lewat **adapters**.
+
+### Adapter Static
+
+Untuk blog atau situs statis (seperti yang kamu baca sekarang), gunakan `@sveltejs/adapter-static`:
+
+```bash
+pnpm add -D @sveltejs/adapter-static
+```
+
+```javascript
+// svelte.config.js
+import adapter from '@sveltejs/adapter-static';
+
+export default {
+  kit: { adapter: adapter() }
+};
+```
+
+Output-nya adalah HTML/CSS/JS statis yang bisa di-host di mana saja — Netlify, Vercel, GitHub Pages, Cloudflare Pages.
+
+### Adapter Node
+
+Untuk aplikasi server-side dengan database atau API:
+
+```bash
+pnpm add -D @sveltejs/adapter-node
+```
+
+Generate Node.js server yang siap jalan di VPS atau container.
+
+### Adapter Vercel / Netlify
+
+Kalau deploy ke platform tertentu, ada adapter khusus yang otomatis mengonfigurasi serverless functions, edge functions, dan image optimization:
+
+```bash
+pnpm add -D @sveltejs/adapter-vercel
+# atau
+pnpm add -D @sveltejs/adapter-netlify
+```
+
+## Optimasi Performa
+
+### Preloading
+
+SvelteKit otomatis mem-prefetch halaman saat link di-hover. Kamu bisa mengontrolnya dengan atribut `data-sveltekit-preload-data`:
+
+```svelte
+<!-- preload agresif saat link masuk viewport -->
+<a href="/blog" data-sveltekit-preload-data="viewport">Blog</a>
+```
+
+### Image Optimization
+
+Gunakan elemen `<enhanced:img>` (via `@sveltejs/enhanced-img`) untuk otomatis resize, convert ke WebP/AVIF, dan lazy-load:
+
+```svelte
+<script>
+  import cover from './cover.jpg?enhanced';
+</script>
+
+<enhanced:img src={cover} alt="Cover" />
+```
+
+## Penutup
+
+SvelteKit adalah salah satu framework web paling ergonomis yang ada saat ini. Dengan file-system routing, load functions yang terpisah bersih dari UI, dan adapter system yang fleksibel, kamu bisa bangun dari blog statis sampai aplikasi full-stack kompleks dengan codebase yang tetap rapi.
+
+Coba mulai dengan project kecil — clone repo ini misalnya — dan rasakan sendiri perbedaannya.

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import type { Heading } from '$lib/posts';
+
+	let { headings }: { headings: Heading[] } = $props();
+
+	let activeSlug = $state<string | null>(null);
+
+	$effect(() => {
+		if (headings.length === 0) return;
+
+		const elements = headings
+			.map((h) => document.getElementById(h.slug))
+			.filter((el): el is HTMLElement => el !== null);
+
+		if (elements.length === 0) return;
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				const visible = entries
+					.filter((entry) => entry.isIntersecting)
+					.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+
+				if (visible[0]) {
+					activeSlug = visible[0].target.id;
+				}
+			},
+			{ rootMargin: '0px 0px -70% 0px', threshold: 0 }
+		);
+
+		for (const el of elements) observer.observe(el);
+
+		return () => observer.disconnect();
+	});
+</script>
+
+{#if headings.length > 0}
+	<nav aria-label="Daftar isi" class="text-sm">
+		<p class="mb-3 font-medium text-foreground">Daftar Isi</p>
+		<ul class="space-y-2 border-l border-border">
+			{#each headings as heading (heading.slug)}
+				<li class:pl-4={heading.depth === 2} class:pl-8={heading.depth === 3}>
+					<a
+						href="#{heading.slug}"
+						class="block -ml-px border-l-2 py-0.5 transition-colors {activeSlug === heading.slug
+							? 'border-foreground font-medium text-foreground'
+							: 'border-transparent text-muted-foreground hover:text-foreground'}"
+					>
+						{heading.text}
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</nav>
+{/if}

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -8,28 +8,25 @@
 	$effect(() => {
 		if (headings.length === 0) return;
 
-		const elements = headings
-			.map((h) => document.getElementById(h.slug))
-			.filter((el): el is HTMLElement => el !== null);
+		function update() {
+			const scrollY = window.scrollY;
+			let current: string | null = null;
 
-		if (elements.length === 0) return;
-
-		const observer = new IntersectionObserver(
-			(entries) => {
-				const visible = entries
-					.filter((entry) => entry.isIntersecting)
-					.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-
-				if (visible[0]) {
-					activeSlug = visible[0].target.id;
+			for (const h of headings) {
+				const el = document.getElementById(h.slug);
+				// heading is "active" when its top edge has passed 96px from viewport top
+				if (el && el.offsetTop - 96 <= scrollY) {
+					current = h.slug;
 				}
-			},
-			{ rootMargin: '0px 0px -70% 0px', threshold: 0 }
-		);
+			}
 
-		for (const el of elements) observer.observe(el);
+			activeSlug = current;
+		}
 
-		return () => observer.disconnect();
+		window.addEventListener('scroll', update, { passive: true });
+		update(); // set active on mount (e.g. when landing via URL hash)
+
+		return () => window.removeEventListener('scroll', update);
 	});
 </script>
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,5 +1,6 @@
 import type { Component } from 'svelte';
 import type { Post, PostMetadata } from '$lib/types/post';
+import GithubSlugger from 'github-slugger';
 
 type GlobModule = { metadata: PostMetadata };
 
@@ -40,6 +41,40 @@ export function getPost(slug: string): PostModule | null {
 	const mod = entry[1];
 	if (mod.metadata.draft) return null;
 	return mod;
+}
+
+export type Heading = {
+	depth: 2 | 3;
+	text: string;
+	slug: string;
+};
+
+export function getHeadings(slug: string): Heading[] {
+	const entry = Object.entries(rawModules).find(([path]) => path.endsWith(`/${slug}.md`));
+	if (!entry) return [];
+
+	const body = entry[1].replace(/^---[\s\S]*?---/, '');
+	const slugger = new GithubSlugger();
+	const headings: Heading[] = [];
+	const lines = body.split('\n');
+
+	let inCodeBlock = false;
+	for (const line of lines) {
+		if (/^```/.test(line)) {
+			inCodeBlock = !inCodeBlock;
+			continue;
+		}
+		if (inCodeBlock) continue;
+
+		const match = /^(#{2,3})\s+(.+?)\s*#*\s*$/.exec(line);
+		if (!match) continue;
+
+		const depth = match[1].length as 2 | 3;
+		const text = match[2].trim();
+		headings.push({ depth, text, slug: slugger.slug(text) });
+	}
+
+	return headings;
 }
 
 export function getReadingTime(slug: string): string {

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { copyCode } from '$lib/actions/copy-code';
+	import Toc from '$lib/components/Toc.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -18,26 +19,34 @@
 	<meta name="description" content={data.metadata.description} />
 </svelte:head>
 
-<article class="mx-auto max-w-2xl">
-	<header class="mb-10">
-		<h1 class="text-3xl font-bold text-foreground">{data.metadata.title}</h1>
-		<div class="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-			<time datetime={data.metadata.date}>{formatDate(data.metadata.date)}</time>
-			<span aria-hidden="true">·</span>
-			<span>{data.readingTime}</span>
-		</div>
-		{#if data.metadata.tags.length > 0}
-			<div class="mt-3 flex flex-wrap gap-2">
-				{#each data.metadata.tags as tag}
-					<span class="rounded-full bg-muted px-2.5 py-0.5 text-xs text-muted-foreground">
-						{tag}
-					</span>
-				{/each}
+<div class="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[minmax(0,1fr)_220px]">
+	<article class="mx-auto w-full max-w-2xl lg:mx-0">
+		<header class="mb-10">
+			<h1 class="text-3xl font-bold text-foreground">{data.metadata.title}</h1>
+			<div class="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+				<time datetime={data.metadata.date}>{formatDate(data.metadata.date)}</time>
+				<span aria-hidden="true">·</span>
+				<span>{data.readingTime}</span>
 			</div>
-		{/if}
-	</header>
+			{#if data.metadata.tags.length > 0}
+				<div class="mt-3 flex flex-wrap gap-2">
+					{#each data.metadata.tags as tag}
+						<span class="rounded-full bg-muted px-2.5 py-0.5 text-xs text-muted-foreground">
+							{tag}
+						</span>
+					{/each}
+				</div>
+			{/if}
+		</header>
 
-	<div class="prose dark:prose-invert max-w-none" use:copyCode>
-		<data.Component />
-	</div>
-</article>
+		<div class="prose dark:prose-invert max-w-none" use:copyCode>
+			<data.Component />
+		</div>
+	</article>
+
+	<aside class="hidden lg:block">
+		<div class="sticky top-24">
+			<Toc headings={data.headings} />
+		</div>
+	</aside>
+</div>

--- a/src/routes/blog/[slug]/+page.ts
+++ b/src/routes/blog/[slug]/+page.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { getPost, getPostSlugs, getReadingTime } from '$lib/posts';
+import { getPost, getPostSlugs, getReadingTime, getHeadings } from '$lib/posts';
 
 export const prerender = true;
 
@@ -14,6 +14,7 @@ export function load({ params }) {
 	return {
 		metadata: post.metadata,
 		Component: post.default,
-		readingTime: getReadingTime(params.slug)
+		readingTime: getReadingTime(params.slug),
+		headings: getHeadings(params.slug)
 	};
 }


### PR DESCRIPTION
Closes #14

## Summary

- Configure `rehype-slug` dan `rehype-autolink-headings` di mdsvex pipeline sehingga setiap heading mendapat `id` dan anchor link
- Tambah `getHeadings()` helper di `posts.ts` menggunakan `github-slugger` agar slug konsisten dengan output rehype-slug
- Buat komponen `Toc.svelte` dengan scroll-spy berbasis scroll event listener (reliabel di semua arah dan saat load via URL hash)
- Update layout `/blog/[slug]` jadi 2-kolom grid — TOC sticky di kanan pada layar `lg`, tersembunyi di mobile
- Anchor `#` di heading hanya muncul saat hover (CSS `opacity: 0` → `opacity: 1`)
- Tambah `scroll-behavior: smooth` dan `scroll-padding-top: 6rem` di CSS global

## Test plan

- [ ] Buka `/blog/toc-demo` di layar ≥ 1024px — TOC muncul di kanan
- [ ] Scroll ke bawah — item TOC aktif berubah mengikuti section
- [ ] Scroll ke atas — highlight mundur dengan benar
- [ ] Klik item TOC — smooth scroll ke heading, tidak tertutup header
- [ ] Resize ke mobile — TOC tersembunyi, layout artikel normal
- [ ] Hover di atas heading — anchor `#` muncul, klik mengubah URL
- [ ] `pnpm check` dan `pnpm build` lulus tanpa error

🤖 Generated with [Claude Code](https://claude.com/claude-code)