### PR TITLE
feat: reading time akurat + komponen Related Posts berbasis tag

### DIFF
--- a/src/lib/components/RelatedPosts.svelte
+++ b/src/lib/components/RelatedPosts.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import type { Post } from '$lib/types/post';
+
+	let { posts }: { posts: Post[] } = $props();
+
+	function formatDate(date: string) {
+		return new Date(date).toLocaleDateString('id-ID', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric'
+		});
+	}
+</script>
+
+{#if posts.length > 0}
+	<section class="mt-16 border-t border-border pt-10">
+		<h2 class="mb-6 text-xl font-semibold text-foreground">Post Terkait</h2>
+		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+			{#each posts as post (post.slug)}
+				<a
+					href="/blog/{post.slug}"
+					class="group flex flex-col rounded-lg border border-border bg-surface/50 p-4 transition-colors hover:border-foreground/30"
+				>
+					<time class="text-xs text-muted-foreground" datetime={post.date}>
+						{formatDate(post.date)}
+					</time>
+					<h3 class="mt-2 font-medium text-foreground group-hover:text-primary">
+						{post.title}
+					</h3>
+					<p class="mt-2 line-clamp-2 text-sm text-muted-foreground">
+						{post.description}
+					</p>
+				</a>
+			{/each}
+		</div>
+	</section>
+{/if}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -80,8 +80,53 @@ export function getHeadings(slug: string): Heading[] {
 export function getReadingTime(slug: string): string {
 	const entry = Object.entries(rawModules).find(([path]) => path.endsWith(`/${slug}.md`));
 	if (!entry) return '';
-	const text = entry[1].replace(/^---[\s\S]*?---/, '');
+
+	let text = entry[1];
+
+	text = text.replace(/^---[\s\S]*?---/, '');
+	text = text.replace(/```[\s\S]*?```/g, ' ');
+	text = text.replace(/`[^`]*`/g, ' ');
+	text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, ' ');
+	text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+	text = text.replace(/<[^>]+>/g, ' ');
+	text = text
+		.replace(/^#{1,6}\s+/gm, '')
+		.replace(/^\s*[-*+]\s+/gm, '')
+		.replace(/^\s*>\s?/gm, '')
+		.replace(/[*_~]+/g, '')
+		.replace(/\|/g, ' ');
+
 	const words = text.trim().split(/\s+/).filter(Boolean).length;
 	const minutes = Math.max(1, Math.ceil(words / 200));
 	return `${minutes} menit baca`;
+}
+
+export function getRelatedPosts(slug: string, limit = 3): Post[] {
+	const all = getAllPosts();
+	const current = all.find((p) => p.slug === slug);
+	if (!current) return [];
+
+	const others = all.filter((p) => p.slug !== slug);
+
+	const scored = others.map((p) => ({
+		post: p,
+		shared: p.tags.filter((t) => current.tags.includes(t)).length
+	}));
+
+	const withSharedTags = scored
+		.filter((s) => s.shared > 0)
+		.sort((a, b) => {
+			if (b.shared !== a.shared) return b.shared - a.shared;
+			return new Date(b.post.date).getTime() - new Date(a.post.date).getTime();
+		})
+		.map((s) => s.post);
+
+	if (withSharedTags.length >= limit) return withSharedTags.slice(0, limit);
+
+	const used = new Set(withSharedTags.map((p) => p.slug));
+	const filler = others
+		.filter((p) => !used.has(p.slug))
+		.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+	return [...withSharedTags, ...filler].slice(0, limit);
 }

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageData } from './$types';
 	import { copyCode } from '$lib/actions/copy-code';
 	import Toc from '$lib/components/Toc.svelte';
+	import RelatedPosts from '$lib/components/RelatedPosts.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -20,29 +21,33 @@
 </svelte:head>
 
 <div class="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[minmax(0,1fr)_220px]">
-	<article class="mx-auto w-full max-w-2xl lg:mx-0">
-		<header class="mb-10">
-			<h1 class="text-3xl font-bold text-foreground">{data.metadata.title}</h1>
-			<div class="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-				<time datetime={data.metadata.date}>{formatDate(data.metadata.date)}</time>
-				<span aria-hidden="true">·</span>
-				<span>{data.readingTime}</span>
-			</div>
-			{#if data.metadata.tags.length > 0}
-				<div class="mt-3 flex flex-wrap gap-2">
-					{#each data.metadata.tags as tag}
-						<span class="rounded-full bg-muted px-2.5 py-0.5 text-xs text-muted-foreground">
-							{tag}
-						</span>
-					{/each}
+	<div class="mx-auto w-full max-w-2xl lg:mx-0">
+		<article>
+			<header class="mb-10">
+				<h1 class="text-3xl font-bold text-foreground">{data.metadata.title}</h1>
+				<div class="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+					<time datetime={data.metadata.date}>{formatDate(data.metadata.date)}</time>
+					<span aria-hidden="true">·</span>
+					<span>{data.readingTime}</span>
 				</div>
-			{/if}
-		</header>
+				{#if data.metadata.tags.length > 0}
+					<div class="mt-3 flex flex-wrap gap-2">
+						{#each data.metadata.tags as tag}
+							<span class="rounded-full bg-muted px-2.5 py-0.5 text-xs text-muted-foreground">
+								{tag}
+							</span>
+						{/each}
+					</div>
+				{/if}
+			</header>
 
-		<div class="prose dark:prose-invert max-w-none" use:copyCode>
-			<data.Component />
-		</div>
-	</article>
+			<div class="prose dark:prose-invert max-w-none" use:copyCode>
+				<data.Component />
+			</div>
+		</article>
+
+		<RelatedPosts posts={data.relatedPosts} />
+	</div>
 
 	<aside class="hidden lg:block">
 		<div class="sticky top-24">

--- a/src/routes/blog/[slug]/+page.ts
+++ b/src/routes/blog/[slug]/+page.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { getPost, getPostSlugs, getReadingTime, getHeadings } from '$lib/posts';
+import { getPost, getPostSlugs, getReadingTime, getHeadings, getRelatedPosts } from '$lib/posts';
 
 export const prerender = true;
 
@@ -15,6 +15,7 @@ export function load({ params }) {
 		metadata: post.metadata,
 		Component: post.default,
 		readingTime: getReadingTime(params.slug),
-		headings: getHeadings(params.slug)
+		headings: getHeadings(params.slug),
+		relatedPosts: getRelatedPosts(params.slug)
 	};
 }


### PR DESCRIPTION
Closes #16

## Summary

- Refactor `getReadingTime()` — strip fenced code blocks, inline code, image syntax, link URL (pertahankan anchor text), HTML tag, dan markdown noise sebelum hitung kata; WPM dan format string tidak berubah
- Tambah `getRelatedPosts(slug, limit=3)` — skor by jumlah shared tag, tie-breaker tanggal terbaru, fallback 3 post terbaru bila tidak ada tag yang sama
- Pass `relatedPosts` dari `+page.ts` ke halaman
- Buat `RelatedPosts.svelte` — card grid responsif (1 kolom mobile / 2 kolom sm / 3 kolom lg), title + date + description truncated
- Restrukturisasi kolom kiri `+page.svelte`: bungkus `<article>` + `<RelatedPosts />` dalam satu `<div>`, TOC tetap di kolom kanan

## Test plan

- [ ] Buka post yang banyak code block (mis. `/blog/syntax-highlighting-test`) — reading time lebih kecil/realistis dibanding sebelumnya
- [ ] Section "Post Terkait" muncul di bawah artikel di semua post
- [ ] Post yang sedang dibuka tidak muncul di list related posts
- [ ] Card responsif: 1 kolom mobile, 2 kolom ≥640px, 3 kolom ≥1024px
- [ ] Klik card → navigasi ke post yang benar
- [ ] TOC sticky di kanan tetap berfungsi normal
- [ ] `pnpm check` dan `pnpm build` lulus tanpa error

🤖 Generated with [Claude Code](https://claude.com/claude-code)