### PR TITLE
feat: blog tags pages — /blog/tags and /blog/tags/[tag]

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -101,6 +101,32 @@ export function getReadingTime(slug: string): string {
 	return `${minutes} menit baca`;
 }
 
+export type TagCount = {
+	tag: string;
+	count: number;
+};
+
+export function getAllTags(): TagCount[] {
+	const posts = getAllPosts();
+	const counts = new Map<string, number>();
+	for (const post of posts) {
+		for (const tag of post.tags) {
+			counts.set(tag, (counts.get(tag) ?? 0) + 1);
+		}
+	}
+	return Array.from(counts.entries())
+		.map(([tag, count]) => ({ tag, count }))
+		.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
+export function getPostsByTag(tag: string): Post[] {
+	return getAllPosts().filter((post) => post.tags.includes(tag));
+}
+
+export function getTagSlugs(): string[] {
+	return getAllTags().map((t) => t.tag);
+}
+
 export function getRelatedPosts(slug: string, limit = 3): Post[] {
 	const all = getAllPosts();
 	const current = all.find((p) => p.slug === slug);

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -21,6 +21,9 @@
 	<header class="mb-10">
 		<h1 class="text-3xl font-bold text-foreground">Blog</h1>
 		<p class="mt-2 text-muted-foreground">Kumpulan tulisan dan catatan.</p>
+		<a href="/blog/tags" class="mt-2 inline-block text-sm text-primary hover:underline">
+			Lihat semua tag →
+		</a>
 	</header>
 
 	{#if data.posts.length === 0}

--- a/src/routes/blog/tags/+page.svelte
+++ b/src/routes/blog/tags/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+	<title>Tags — Lookqup</title>
+	<meta name="description" content="Telusuri tulisan berdasarkan topik di Lookqup." />
+</svelte:head>
+
+<div class="mx-auto max-w-2xl">
+	<header class="mb-10">
+		<h1 class="text-3xl font-bold text-foreground">Tags</h1>
+		<p class="mt-2 text-muted-foreground">Telusuri tulisan berdasarkan topik.</p>
+	</header>
+
+	{#if data.tags.length === 0}
+		<p class="text-muted-foreground">Belum ada tag.</p>
+	{:else}
+		<ul class="flex flex-col gap-3">
+			{#each data.tags as { tag, count }}
+				<li>
+					<a
+						href="/blog/tags/{tag}"
+						class="flex items-center justify-between rounded-xl border border-border bg-surface px-5 py-4 transition-colors hover:border-primary hover:bg-muted"
+					>
+						<span class="font-medium text-foreground">{tag}</span>
+						<span class="text-sm text-muted-foreground">{count} post</span>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/src/routes/blog/tags/+page.ts
+++ b/src/routes/blog/tags/+page.ts
@@ -1,0 +1,7 @@
+import { getAllTags } from '$lib/posts';
+
+export const prerender = true;
+
+export function load() {
+	return { tags: getAllTags() };
+}

--- a/src/routes/blog/tags/[tag]/+page.svelte
+++ b/src/routes/blog/tags/[tag]/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	function formatDate(date: string) {
+		return new Date(date).toLocaleDateString('id-ID', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric'
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>Tag: {data.tag} — Lookqup</title>
+	<meta name="description" content="Tulisan dengan tag {data.tag} di Lookqup." />
+</svelte:head>
+
+<div class="mx-auto max-w-2xl">
+	<header class="mb-10">
+		<a href="/blog/tags" class="mb-4 inline-block text-sm text-primary hover:underline">
+			← Semua tag
+		</a>
+		<h1 class="text-3xl font-bold text-foreground">Tag: {data.tag}</h1>
+		<p class="mt-2 text-muted-foreground">{data.posts.length} post dengan tag ini.</p>
+	</header>
+
+	<ul class="flex flex-col gap-4">
+		{#each data.posts as post}
+			<li>
+				<a
+					href="/blog/{post.slug}"
+					class="block rounded-xl border border-border bg-surface p-5 transition-colors hover:border-primary hover:bg-muted"
+				>
+					<article>
+						<h2 class="text-lg font-semibold text-foreground">{post.title}</h2>
+						<time class="mt-1 block text-xs text-muted-foreground" datetime={post.date}>
+							{formatDate(post.date)}
+						</time>
+						<p class="mt-2 text-sm text-muted-foreground">{post.description}</p>
+						{#if post.tags.length > 0}
+							<div class="mt-3 flex flex-wrap gap-2">
+								{#each post.tags as tag}
+									<span class="rounded-full bg-muted px-2.5 py-0.5 text-xs text-muted-foreground">
+										{tag}
+									</span>
+								{/each}
+							</div>
+						{/if}
+					</article>
+				</a>
+			</li>
+		{/each}
+	</ul>
+</div>

--- a/src/routes/blog/tags/[tag]/+page.ts
+++ b/src/routes/blog/tags/[tag]/+page.ts
@@ -1,0 +1,15 @@
+import { error } from '@sveltejs/kit';
+import { getPostsByTag, getTagSlugs } from '$lib/posts';
+
+export const prerender = true;
+
+export function entries() {
+	return getTagSlugs().map((tag) => ({ tag }));
+}
+
+export function load({ params }) {
+	const posts = getPostsByTag(params.tag);
+	if (posts.length === 0) throw error(404, 'Tag tidak ditemukan');
+
+	return { tag: params.tag, posts };
+}


### PR DESCRIPTION
Closes #18

## Summary

- Added `getAllTags()`, `getPostsByTag()`, `getTagSlugs()` helpers to `src/lib/posts.ts`
- New page `/blog/tags` — lists all tags sorted by post count (desc), then alphabetically
- New page `/blog/tags/[tag]` — lists posts for a given tag, with back-link to all tags
- Added "Lihat semua tag →" link in `/blog` header
- All pages statically prerendered via `adapter-static`; post drafts excluded from tag counts

## Test plan

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm build` — succeeded; `build/blog/tags.html` and `build/blog/tags/*.html` per tag all generated
- [x] Manual: `/blog/tags` shows all tags with correct post counts
- [x] Manual: clicking a tag navigates to `/blog/tags/[tag]` with correct post list
- [x] Manual: draft posts do not appear in tag counts or post lists
- [x] Manual: unknown tag URL → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)